### PR TITLE
Fix selection for transitions  

### DIFF
--- a/src/GraphicView.cpp
+++ b/src/GraphicView.cpp
@@ -2903,7 +2903,7 @@ void jpsGraphicsView::addLayer()
     qDebug("Enter jpsGraphicsView::addLayer");
     auto *layer = new Layer();
 
-//    this->scene()->addItem(layer); // Add layer into scene
+    this->scene()->addItem(layer); // Add layer into scene
 
     layer_list.append(layer);
     qDebug("Leave jpsGraphicsView::addLayer");

--- a/src/GraphicView.cpp
+++ b/src/GraphicView.cpp
@@ -1015,7 +1015,7 @@ void jpsGraphicsView::catch_line_point()
 void jpsGraphicsView::catch_lines()
 {
     qDebug("Enter jpsGraphicsView::catch_lines");
-    // Catch elements (only possible if wall is disabled) which haven't own widget (exp. transitions, sources, goals)
+    // Catch wall, crossing, transition, track, hline
     // If current rect was build up moving the cursor to the left ->
     // Whole line has to be within the rect to select the line
     line_tracked=-1;
@@ -1025,17 +1025,26 @@ void jpsGraphicsView::catch_lines()
         for (auto &item:line_vector)
         {
             if (currentSelectRect->contains(item->get_line()->line().p1())
-                    && currentSelectRect->contains(item->get_line()->line().p2())
-                    && item->get_defaultColor()!="white")
+                && currentSelectRect->contains(item->get_line()->line().p2())
+                && item->get_defaultColor()!="white")
             {
                 markLine(item);
             }
         }
 
+        // select transitions
+        for (auto item:_datamanager->getTransitionList())
+        {
+            if (currentSelectRect->contains(item->get_cLine()->get_line()->line().p1())
+                && currentSelectRect->contains(item->get_cLine()->get_line()->line().p2()))
+            {
+                markLine(item->get_cLine());
+            }
+        }
 
     }
-    // Ff current rect was build up moving the cursor to the right ->
-    // Throwing the select rect only over a part of a line is sufficent to select it
+        // Ff current rect was build up moving the cursor to the right ->
+        // Throwing the select rect only over a part of a line is sufficent to select it
     else if (currentSelectRect->rect().width()>0)
     {
         for (auto &item : line_vector)
@@ -1047,6 +1056,15 @@ void jpsGraphicsView::catch_lines()
             }
         }
 
+        // select transitions
+        for (auto item:_datamanager->getTransitionList())
+        {
+            if (currentSelectRect->collidesWithItem(item->get_cLine()->get_line()))
+            {
+                markLine(item->get_cLine());
+                line_tracked=1;
+            }
+        }
     }
     qDebug("Leave jpsGraphicsView::catch_lines");
 }

--- a/src/GraphicView.h
+++ b/src/GraphicView.h
@@ -56,6 +56,8 @@ public:
     //Destructor
     ~jpsGraphicsView() override;
 
+    void removeContents();
+
     QGraphicsScene *GetScene();
     const qreal& GetTranslationX() const;
     const qreal& GetTranslationY() const;
@@ -68,7 +70,6 @@ public:
     void SetDatamanager(jpsDatamanager* datamanager);
 
     //Change modes
-
     void setDrawingMode(DrawingMode mode);
 
     void change_stat_anglesnap();
@@ -92,7 +93,6 @@ public:
 
     void drawGoal();
     void enableGoalMode();
-
 
     // global functions
     qreal get_scale_f();
@@ -151,8 +151,8 @@ public:
     void deleteMarkedLandmark();
     void catch_landmark();
     void select_landmark(jpsLandmark *landmark);
-    void addLandmark();
-    void addLandmark(const QPointF& pos);
+    void drawLandmark();
+    void drawLandmark(const QPointF& pos);
     // unmark Landmarks see slots
 
     //Connections and YAHPointer
@@ -245,18 +245,15 @@ protected slots:
 
 private:
     jpsDatamanager* _datamanager;
+
     QGraphicsLineItem* current_line;
     QPolygonF polygon;
-    //std::vector<jpsLineItem> line_vector;
     QList<QPointF *> intersect_point_vector;
-    //QList<QPointF> grid_point_vector;
     QList<jpsLineItem *> line_vector;
     QList<QGraphicsLineItem *> _origin;
-    //QList<QList<jpsLineItem*> *> mainlist;
 
     QPointF pos; // position of the mouse cursor;
 
-//    QPointF* intersection_point;
     bool midbutton_hold;
     bool leftbutton_hold;
 
@@ -335,6 +332,7 @@ private:
     // Layer
     QList<Layer *> layer_list;
 
+    // Background
     QGraphicsPixmapItem *background;
 
 signals:

--- a/src/datamanager.cpp
+++ b/src/datamanager.cpp
@@ -40,6 +40,7 @@ jpsDatamanager::jpsDatamanager(QWidget *parent, jpsGraphicsView *view)
 {
     qDebug("Enter jpsDatamanager::jpsDatamanager");
     parent_widget=parent;
+
     _mView=view;
     obs_id_counter=0;
     _crossingIdCounter=1;
@@ -1609,8 +1610,8 @@ void jpsDatamanager::remove_all()
     removeAllSource();
 
     remove_all_rooms();
-
     remove_all_obstacles();
+
     remove_all_landmarks();
     RemoveAllConnections();
     RemoveAllRegions();
@@ -2617,7 +2618,7 @@ void jpsDatamanager::ParseLandmark(jpsRegion *actRegion, QXmlStreamReader &xmlRe
 
 
     //create landmark incl. pixmap
-    _mView->addLandmark(QPointF(real_x,real_y));
+    _mView->drawLandmark(QPointF(real_x, real_y));
 
     _landmarks.back()->SetId(id);
     _landmarks.back()->SetCaption(caption);

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -285,7 +285,6 @@ MWindow::~MWindow()
     delete label2;
     delete infoLabel;
     delete timer;
-//    delete _cMapTimer;
     delete drawing_toolbar_;
     qDebug("Leave MWindow::~MWindow");
 }
@@ -993,7 +992,7 @@ void MWindow::deleteAllContents()
     dmanager->remove_all();
 
     // Delete all QGraphicsitem in view
-    mview->delete_all();
+    mview->removeContents();
 
     emit mview->sourcesChanged(); // emit to update source widget
     emit mview->goalsChanged(); // emit to update goal widget

--- a/src/models/layer.cpp
+++ b/src/models/layer.cpp
@@ -61,7 +61,7 @@ void Layer::setName(QString layername)
 
 QList<jpsLineItem *> Layer::getLineItemList()
 {
-    qDebug("Enter/Leave Layer::getItemLis");
+    qDebug("Enter/Leave Layer::getItemList");
     return lineItem_list;
 }
 

--- a/src/models/layer.cpp
+++ b/src/models/layer.cpp
@@ -36,6 +36,7 @@ Layer::Layer() : QGraphicsItemGroup(nullptr)
     qDebug("Enter Layer::Layer");
     name = "Layer";
     visible = true;
+
     qDebug("Leave Layer::Layer");
 }
 
@@ -85,7 +86,7 @@ void Layer::addLineToLayer(jpsLineItem *wall)
         return;
 
     lineItem_list.append(wall);
-    addToGroup(wall->get_line());
+    addToGroup(wall->get_line()); // Add line into the group of this layer
     qDebug("Leave Layer::addLineToLayer");
 }
 
@@ -99,4 +100,3 @@ void Layer::removeLineFromLayer(jpsLineItem *line)
     lineItem_list.removeOne(line);
     qDebug("Leave Layer::removeLineFromLayer");
 }
-

--- a/src/widgets/layerwidget.h
+++ b/src/widgets/layerwidget.h
@@ -31,7 +31,7 @@ protected slots:
     void showLayerButtonClicked();
 
     void addItemsButtonClicked();
-    void updateItemsListWidget();
+    void updateItemsListWidget(QListWidgetItem *item);
     void removeItemsButtonClicked();
 
     bool isRepeatedName(QString name);


### PR DESCRIPTION
* For issue #13: Transitions can be selected in view and layer widget

## Add
* jpsGraphicsView::removeContents()

## Refactoring
* jpsGraphicsView::catch_lines()
* LayerWidget::updateItemsListWidget(QListWidgetItem *item)
* jpsGraphicsView::delete_all()
* void MWindow::deleteAllContents()
